### PR TITLE
Fix for older browser support and executable change for browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "linter": "eslint .",
     "coverage": "istanbul cover _mocha",
     "pretest": "npm run --silent linter",
-    "dist": "./node_modules/.bin/browserify src/view/browser.js --s createWebshell -p licensify -o dist/webshell.js -t  [ babelify --presets [ es2015-script ] ]",
+    "dist": "browserify src/view/browser.js --s createWebshell -p licensify -o dist/webshell.js -t  [ babelify --presets [ es2015-script ] ]",
     "dist-watch": "watchify src/view/browser.js --s createWebshell -p licensify -o dist/webshell.js -t  [ babelify --presets [ es2015-script ] ]"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "coverage": "istanbul cover _mocha",
     "pretest": "npm run --silent linter",
     "dist": "./node_modules/.bin/browserify src/view/browser.js --s createWebshell -p licensify -o dist/webshell.js -t  [ babelify --presets [ es2015-script ] ]",
-    "dist-watch": "watchify src/view/browser.js --s createWebshell -p licensify -o dist/webshell.js"
+    "dist-watch": "watchify src/view/browser.js --s createWebshell -p licensify -o dist/webshell.js -t  [ babelify --presets [ es2015-script ] ]"
   },
   "devDependencies": {
     "babel-preset-es2015-script": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -12,10 +12,12 @@
     "linter": "eslint .",
     "coverage": "istanbul cover _mocha",
     "pretest": "npm run --silent linter",
-    "dist": "browserify src/view/browser.js --s createWebshell -p licensify -o dist/webshell.js",
+    "dist": "./node_modules/.bin/browserify src/view/browser.js --s createWebshell -p licensify -o dist/webshell.js -t  [ babelify --presets [ es2015-script ] ]",
     "dist-watch": "watchify src/view/browser.js --s createWebshell -p licensify -o dist/webshell.js"
   },
   "devDependencies": {
+    "babel-preset-es2015-script": "^1.1.0",
+    "babelify": "^7.3.0",
     "browserify": "^13.1.0",
     "eslint": "^3.1.1",
     "eslint-config-standard": "^5.3.5",


### PR DESCRIPTION
This changes is to fix the issue when running `npm run dist` with no dist folder
## Issue:
- older browser with no support for es6 will not able to run this
- dist folder not created resolve in

```
> webshell.js@0.0.1 dist /home/juliosueiras/projects/juliosueiras.github.io/webshell.js
> browserify src/view/browser.js --s createWebshell -p licensify -o dist/webshell.js

events.js:154
      throw er; // Unhandled 'error' event
      ^

Error: ENOENT: no such file or directory, open 'dist/webshell.js'
    at Error (native)
```
## Solution:
- added babelify to transform to neutral javascript code
- added dist folder
